### PR TITLE
Handle blocks interleaving

### DIFF
--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -25,6 +25,7 @@
     "@babel/core": "^7.4.4",
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/plugin-syntax-jsx": "^7.2.0",
+    "@mdx-js/mdx": "^1.0.16",
     "remark-mdx": "^1.0.15",
     "remark-parse": "^6.0.3",
     "remark-squeeze-paragraphs": "^3.0.3",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -31,6 +31,7 @@
     "remark-stringify": "^6.0.4",
     "slate": "^0.45.0",
     "slate-mdast-serializer": "^3.0.0",
-    "unified": "^7.1.0"
+    "unified": "^7.1.0",
+    "unist-util-visit": "^1.4.0"
   }
 }

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -25,7 +25,6 @@
     "@babel/core": "^7.4.4",
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/plugin-syntax-jsx": "^7.2.0",
-    "@mdx-js/mdx": "^1.0.16",
     "remark-mdx": "^1.0.15",
     "remark-parse": "^6.0.3",
     "remark-squeeze-paragraphs": "^3.0.3",

--- a/packages/serializer/src/index.js
+++ b/packages/serializer/src/index.js
@@ -5,7 +5,9 @@ const remarkParse = require('remark-parse')
 const remarkSqueezeParagraphs = require('remark-squeeze-paragraphs')
 const mdx = require('remark-mdx')
 const { Data } = require('slate')
+
 const { parseJSXBlock, applyProps } = require('./parse-jsx')
+const remarkInterleave = require('./remark-interleave').default
 
 const parser = unified()
   .use(remarkParse, {
@@ -13,7 +15,8 @@ const parser = unified()
     position: false
   })
   .use(remarkSqueezeParagraphs)
-  .use(_ => ast => console.log(ast) || ast)
+  .use(remarkInterleave)
+  .use(() => ast => console.log(ast) || ast)
   .use(mdx)
 
 export const parseMDX = md => parser.runSync(parser.parse(md))

--- a/packages/serializer/src/remark-interleave.js
+++ b/packages/serializer/src/remark-interleave.js
@@ -1,0 +1,31 @@
+import visit from 'unist-util-visit'
+
+import { isOpenTag, isCloseTag } from './util'
+
+export default () => ast => {
+  visit(ast, 'jsx', (node, index, parent) => {
+    if (!isCloseTag(node.value)) {
+      return
+    }
+
+    for (let i = index - 1; i >= 0; i--) {
+      // This should eventually check to also make sure that the JSX blocks
+      // wrapping Markdown have matching tag names as well.
+      if (isOpenTag(parent.children[i].value)) {
+        const open = parent.children[i]
+        open.children = [{ type: 'jsx', value: open.value }]
+
+        for (let j = i + 1; j <= index; j++) {
+          const child = parent.children[j]
+          open.children.push(child)
+        }
+
+        open.children.push(node)
+        parent.children.splice(i + 1, index - 1)
+        delete open.value
+      }
+    }
+  })
+
+  return ast
+}

--- a/packages/serializer/src/remark-interleave.js
+++ b/packages/serializer/src/remark-interleave.js
@@ -20,7 +20,6 @@ export default () => ast => {
           open.children.push(child)
         }
 
-        open.children.push(node)
         parent.children.splice(i + 1, index - 1)
         delete open.value
       }

--- a/packages/serializer/src/util.js
+++ b/packages/serializer/src/util.js
@@ -1,3 +1,8 @@
 export const isCloseTag = (str = '') =>
   str.startsWith('</') || str.endsWith('/>')
 export const isOpenTag = (str = '') => !isCloseTag(str) && str.endsWith('>')
+
+export const getComponentName = (str = '') => {
+  const match = str.match(/^\<?([\w\.\_]+)/)
+  return match && match[1]
+}

--- a/packages/serializer/src/util.js
+++ b/packages/serializer/src/util.js
@@ -1,0 +1,3 @@
+export const isCloseTag = (str = '') =>
+  str.startsWith('</') || str.endsWith('/>')
+export const isOpenTag = (str = '') => !isCloseTag(str) && str.endsWith('>')

--- a/packages/serializer/test/__snapshots__/parse-mdx.test.js.snap
+++ b/packages/serializer/test/__snapshots__/parse-mdx.test.js.snap
@@ -1,6 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`it parses a basic block 1`] = `
+exports[`handles an interleaved block 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Hello, ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "world!",
+            },
+          ],
+          "type": "strong",
+        },
+      ],
+      "depth": 1,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "jsx",
+          "value": "<Block>",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "Other",
+            },
+          ],
+          "depth": 2,
+          "type": "heading",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "Stuff",
+            },
+          ],
+          "type": "paragraph",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</Block>",
+        },
+        Object {
+          "type": "jsx",
+          "value": "</Block>",
+        },
+      ],
+      "type": "jsx",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "And more stuff",
+        },
+      ],
+      "type": "paragraph",
+    },
+  ],
+  "type": "root",
+}
+`;
+
+exports[`parses a basic block 1`] = `
 Object {
   "children": Array [
     Object {

--- a/packages/serializer/test/__snapshots__/parse-mdx.test.js.snap
+++ b/packages/serializer/test/__snapshots__/parse-mdx.test.js.snap
@@ -51,10 +51,6 @@ Object {
           "type": "jsx",
           "value": "</Block>",
         },
-        Object {
-          "type": "jsx",
-          "value": "</Block>",
-        },
       ],
       "type": "jsx",
     },

--- a/packages/serializer/test/__snapshots__/serializer.test.js.snap
+++ b/packages/serializer/test/__snapshots__/serializer.test.js.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`correctly serializes MDX to Slate schema 1`] = `
+Object {
+  "document": Object {
+    "data": Object {},
+    "nodes": Array [
+      Object {
+        "data": Object {},
+        "nodes": Array [
+          Object {
+            "leaves": Array [
+              Object {
+                "marks": Array [],
+                "object": "leaf",
+                "text": "Hello, ",
+              },
+              Object {
+                "marks": Array [
+                  Object {
+                    "data": Object {},
+                    "object": "mark",
+                    "type": "bold",
+                  },
+                ],
+                "object": "leaf",
+                "text": "world!",
+              },
+            ],
+            "object": "text",
+          },
+        ],
+        "object": "block",
+        "type": "heading-one",
+      },
+      Object {
+        "data": Object {
+          "props": Immutable.Map {},
+          "type": "Block",
+        },
+        "nodes": Array [
+          Object {
+            "data": Object {},
+            "nodes": Array [
+              Object {
+                "leaves": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "leaf",
+                    "text": "Other",
+                  },
+                ],
+                "object": "text",
+              },
+            ],
+            "object": "block",
+            "type": "heading-two",
+          },
+          Object {
+            "data": Object {},
+            "nodes": Array [
+              Object {
+                "leaves": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "leaf",
+                    "text": "Stuff",
+                  },
+                ],
+                "object": "text",
+              },
+            ],
+            "object": "block",
+            "type": "paragraph",
+          },
+        ],
+        "object": "block",
+        "type": "Block",
+      },
+      Object {
+        "data": Object {},
+        "nodes": Array [
+          Object {
+            "leaves": Array [
+              Object {
+                "marks": Array [],
+                "object": "leaf",
+                "text": "And more stuff",
+              },
+            ],
+            "object": "text",
+          },
+        ],
+        "object": "block",
+        "type": "paragraph",
+      },
+    ],
+    "object": "document",
+  },
+  "object": "value",
+}
+`;

--- a/packages/serializer/test/parse-mdx.test.js
+++ b/packages/serializer/test/parse-mdx.test.js
@@ -10,10 +10,18 @@ const FIXTURE = `
 Stuff
 
 </Block>
+
+And more stuff
 `
 
-test('it parses a basic block', () => {
+test('parses a basic block', () => {
   const result = parseMDX('# Hello, world!')
+
+  expect(result).toMatchSnapshot()
+})
+
+test('handles an interleaved block', () => {
+  const result = parseMDX(FIXTURE)
 
   expect(result).toMatchSnapshot()
 })

--- a/packages/serializer/test/serializer.test.js
+++ b/packages/serializer/test/serializer.test.js
@@ -1,0 +1,21 @@
+import { serializer, parseMDX } from '../src'
+
+const FIXTURE = `
+# Hello, __world!__
+
+<Block>
+
+## Other
+
+Stuff
+
+</Block>
+
+And more stuff
+`
+
+test('correctly serializes MDX to Slate schema', () => {
+  const result = serializer.deserialize(parseMDX(FIXTURE))
+
+  expect(result.toJSON()).toMatchSnapshot()
+})

--- a/packages/serializer/test/util.test.js
+++ b/packages/serializer/test/util.test.js
@@ -1,0 +1,25 @@
+import * as util from '../src/util'
+
+const OPEN_TAGS = ['<Block>', '<Block foo="bar">']
+
+const CLOSE_TAGS = ['<Block />', '</Block>']
+
+OPEN_TAGS.forEach(tag => {
+  test(`isOpenTag returns true for ${tag}`, () => {
+    expect(util.isOpenTag(tag)).toBeTruthy()
+  })
+
+  test(`isCloseTag returns false for ${tag}`, () => {
+    expect(util.isCloseTag(tag)).toBeFalsy()
+  })
+})
+
+CLOSE_TAGS.forEach(tag => {
+  test(`isOpenTag returns false for ${tag}`, () => {
+    expect(util.isOpenTag(tag)).toBeFalsy()
+  })
+
+  test(`isCloseTag returns true for ${tag}`, () => {
+    expect(util.isCloseTag(tag)).toBeTruthy()
+  })
+})

--- a/packages/serializer/test/util.test.js
+++ b/packages/serializer/test/util.test.js
@@ -23,3 +23,9 @@ CLOSE_TAGS.forEach(tag => {
     expect(util.isCloseTag(tag)).toBeTruthy()
   })
 })
+
+test('getComponentName returns the component name', () => {
+  expect(util.getComponentName('<Block>')).toEqual('Block')
+  expect(util.getComponentName('<Block style={{}}>')).toEqual('Block')
+  expect(util.getComponentName('<Foo.Bar>')).toEqual('Foo.Bar')
+})


### PR DESCRIPTION
Blocks interleaving will be used to allow wrapping
of editable content with special styling. This requires
transforming the initial AST from remark/MDX because
it parses open/close blocks as separate. This will likely
need to be improved but gets us somewhere for now.

### What is blocks interleaving?

This is when MD is embedded within a JSX block. We
will use this format to allow wrapping components of
more content that's editable.

```md
<MyComponent>

## My markdown and such

</MyComponent>
```