### PR TITLE
Proof of concept generic JSX block types

### DIFF
--- a/packages/editor/src/lib/schema.js
+++ b/packages/editor/src/lib/schema.js
@@ -22,10 +22,7 @@ export default {
     hr: {
       isVoid: true
     },
-    youtube: {
-      isVoid: true
-    },
-    gist: {
+    'jsx-void': {
       isVoid: true
     }
   }

--- a/packages/editor/src/plugins/jsx-blocks/Form.js
+++ b/packages/editor/src/plugins/jsx-blocks/Form.js
@@ -30,7 +30,12 @@ export default ({ fields, value, onSubmit }) => {
               name={key}
               value={state[key] || ''}
               onChange={e => {
-                setState({ ...state, [key]: e.target.value })
+                const format = fields[key].formatValue
+                const value =
+                  typeof format === 'function'
+                    ? format(e.target.value)
+                    : e.target.value
+                setState({ ...state, [key]: value })
               }}
             />
           </Label>

--- a/packages/editor/src/plugins/jsx-blocks/Form.js
+++ b/packages/editor/src/plugins/jsx-blocks/Form.js
@@ -1,0 +1,42 @@
+/** @jsx jsx */
+// generic block form
+import { jsx } from '@emotion/core'
+import { useState } from 'react'
+import { Flex } from 'theme-ui/layout'
+
+import Label from '../../components/Label'
+import Input from '../../components/Input'
+import Button from '../../components/Button'
+
+export default ({ fields, value, onSubmit }) => {
+  const [state, setState] = useState(value)
+  const keys = Object.keys(fields)
+  return (
+    <form
+      onClick={e => {
+        e.stopPropagation()
+      }}
+      onSubmit={e => {
+        e.preventDefault()
+        onSubmit(state)
+      }}
+    >
+      <Flex flexWrap="wrap" alignItems="flex-end">
+        {keys.map(key => (
+          <Label key={key} mr={2}>
+            {fields[key].title || key}
+            <Input
+              type="text"
+              name={key}
+              value={state[key] || ''}
+              onChange={e => {
+                setState({ ...state, [key]: e.target.value })
+              }}
+            />
+          </Label>
+        ))}
+        <Button>Apply</Button>
+      </Flex>
+    </form>
+  )
+}

--- a/packages/editor/src/plugins/jsx-blocks/Gist.js
+++ b/packages/editor/src/plugins/jsx-blocks/Gist.js
@@ -68,8 +68,11 @@ export default ({ editor, node, attributes, props, isSelected }) => {
       {isSelected && (
         <Form
           value={props}
-          onSubmit={data => {
-            editor.setJSXProps(data)
+          onSubmit={next => {
+            editor.setJSXProps({
+              type: 'Gist',
+              props: next
+            })
           }}
         />
       )}

--- a/packages/editor/src/plugins/jsx-blocks/Gist.js
+++ b/packages/editor/src/plugins/jsx-blocks/Gist.js
@@ -1,81 +1,26 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
-import { useState } from 'react'
-import Gist from 'react-gist'
-import { Flex } from 'theme-ui/layout'
+import ReactGist from 'react-gist'
 
-import Overlay from './Overlay'
-import Card from '../../components/Card'
-import Label from '../../components/Label'
-import Input from '../../components/Input'
-import Button from '../../components/Button'
-
-const Form = ({ value, onSubmit }) => {
-  const [state, setState] = useState({ id: value.id || '' })
-  return (
-    <Card
-      css={{
-        marginBottom: 8
-      }}
-    >
-      <form
-        onClick={e => {
-          e.stopPropagation()
-        }}
-        onSubmit={e => {
-          e.preventDefault()
-          onSubmit(state)
-        }}
-      >
-        <Flex alignItems="flex-end">
-          <Label mr={2}>
-            Gist ID:
-            <Input
-              type="text"
-              name="id"
-              value={state.id}
-              onChange={e => {
-                setState({ ...state, id: e.target.value })
-              }}
-            />
-          </Label>
-          <Button>Apply</Button>
-        </Flex>
-      </form>
-    </Card>
-  )
-}
-
-export default ({ editor, node, attributes, props, isSelected }) => {
+const Gist = props => {
   return (
     <div>
-      <div
-        {...attributes}
-        style={{
-          position: 'relative',
-          outline: isSelected ? '2px solid blue' : null
-        }}
-      >
-        {props.id ? (
-          <div style={{ marginLeft: -8, marginRight: -8 }}>
-            <Gist {...props} />
-          </div>
-        ) : (
-          <pre>Enter a Gist ID</pre>
-        )}
-        {!isSelected && <Overlay />}
-      </div>
-      {isSelected && (
-        <Form
-          value={props}
-          onSubmit={next => {
-            editor.setJSXProps({
-              type: 'Gist',
-              props: next
-            })
-          }}
-        />
+      {props.id ? (
+        <div style={{ marginLeft: -8, marginRight: -8 }}>
+          <ReactGist {...props} />
+        </div>
+      ) : (
+        <pre>Enter a Gist ID</pre>
       )}
     </div>
   )
 }
+
+Gist.propertyControls = {
+  id: {
+    type: 'string',
+    title: 'Gist ID'
+  }
+}
+
+export default Gist

--- a/packages/editor/src/plugins/jsx-blocks/YouTube.js
+++ b/packages/editor/src/plugins/jsx-blocks/YouTube.js
@@ -4,12 +4,6 @@ import Player from 'react-youtube'
 import isURL from 'is-url'
 import getYouTubeID from 'get-youtube-id'
 
-/* TODO
-const videoId = isURL(e.target.value)
-  ? getYouTubeID(e.target.value)
-  : e.target.value
-*/
-
 const Wrapper = props => (
   <div
     {...props}
@@ -45,7 +39,8 @@ const YouTube = props => {
 YouTube.propertyControls = {
   videoId: {
     type: 'string',
-    title: 'Video ID'
+    title: 'Video ID',
+    formatValue: n => (isURL(n) ? getYouTubeID(n) : n)
   }
 }
 

--- a/packages/editor/src/plugins/jsx-blocks/YouTube.js
+++ b/packages/editor/src/plugins/jsx-blocks/YouTube.js
@@ -94,7 +94,10 @@ export default ({ editor, node, attributes, props, isSelected }) => {
         <YouTubeForm
           value={getProps(node)}
           onSubmit={next => {
-            editor.setJSXProps(next)
+            editor.setJSXProps({
+              type: 'YouTube',
+              props: next
+            })
           }}
         />
       )}

--- a/packages/editor/src/plugins/jsx-blocks/YouTube.js
+++ b/packages/editor/src/plugins/jsx-blocks/YouTube.js
@@ -1,53 +1,14 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core'
-import React, { useState } from 'react'
 import Player from 'react-youtube'
-import { Flex } from 'theme-ui/layout'
 import isURL from 'is-url'
 import getYouTubeID from 'get-youtube-id'
 
-import Overlay from './Overlay'
-import Label from '../../components/Label'
-import Input from '../../components/Input'
-import Button from '../../components/Button'
-
-export const YouTubeForm = ({ value, onSubmit }) => {
-  const [state, setState] = useState({
-    videoId: value.videoId || ''
-  })
-  return (
-    <form
-      css={{
-        padding: 8
-      }}
-      onClick={e => {
-        e.stopPropagation()
-      }}
-      onSubmit={e => {
-        e.preventDefault()
-        onSubmit(state)
-      }}
-    >
-      <Flex flexWrap="wrap" alignItems="flex-end">
-        <Label mr={2}>
-          Video ID:
-          <Input
-            type="text"
-            name="videoId"
-            value={state.videoId}
-            onChange={e => {
-              const videoId = isURL(e.target.value)
-                ? getYouTubeID(e.target.value)
-                : e.target.value
-              setState({ ...state, videoId })
-            }}
-          />
-        </Label>
-        <Button>Apply</Button>
-      </Flex>
-    </form>
-  )
-}
+/* TODO
+const videoId = isURL(e.target.value)
+  ? getYouTubeID(e.target.value)
+  : e.target.value
+*/
 
 const Wrapper = props => (
   <div
@@ -72,35 +33,20 @@ const Wrapper = props => (
   />
 )
 
-const getProps = node => {
-  const map = node.data.get('props')
-  if (!map || typeof map.toJS !== 'function') return map
-  return map.toJS()
-}
-
-export default ({ editor, node, attributes, props, isSelected }) => {
+const YouTube = props => {
   return (
-    <div>
-      <Wrapper
-        {...attributes}
-        style={{
-          outline: isSelected ? '2px solid blue' : null
-        }}
-      >
-        {props.videoId ? <Player {...props} /> : <pre>Enter a YouTube ID</pre>}
-        {!isSelected && <Overlay />}
-      </Wrapper>
-      {isSelected && (
-        <YouTubeForm
-          value={getProps(node)}
-          onSubmit={next => {
-            editor.setJSXProps({
-              type: 'YouTube',
-              props: next
-            })
-          }}
-        />
-      )}
-    </div>
+    <Wrapper>
+      {props.videoId ? <Player {...props} /> : <pre>Enter a YouTube ID</pre>}
+    </Wrapper>
   )
 }
+
+// mimicking Framer X - could make this compatible
+YouTube.propertyControls = {
+  videoId: {
+    type: 'string',
+    title: 'Video ID'
+  }
+}
+
+export default YouTube

--- a/packages/editor/src/plugins/jsx-blocks/index.js
+++ b/packages/editor/src/plugins/jsx-blocks/index.js
@@ -97,7 +97,6 @@ export default (opts = {}) => ({
 
     if (components[type]) {
       const Component = components[type]
-      console.log(node.data.toJS(), getProps(node))
       return (
         <Wrapper
           {...props}

--- a/packages/editor/src/plugins/jsx-blocks/index.js
+++ b/packages/editor/src/plugins/jsx-blocks/index.js
@@ -3,28 +3,29 @@ import { Data } from 'slate'
 import YouTube from './YouTube'
 import Gist from './Gist'
 
-const setJSXProps = (editor, propsObject) => {
-  const props = Data.create(propsObject)
-  editor.setBlocks({ data: { props } })
+const setJSXProps = (editor, dataObject) => {
+  const data = Data.create(dataObject)
+  editor.setBlocks({ data })
 }
 
 const insertJSXBlock = (editor, type, props) => {
   editor.insertBlock({
-    type,
+    type: 'jsx-void',
     data: {
+      type,
       props: Data.create(props)
     }
   })
 }
 
 const insertYouTube = editor => {
-  editor.insertJSXBlock('youtube', {
+  editor.insertJSXBlock('YouTube', {
     videoId: ''
   })
 }
 
 const insertGist = editor => {
-  editor.insertJSXBlock('gist', {
+  editor.insertJSXBlock('Gist', {
     id: ''
   })
 }
@@ -44,12 +45,14 @@ export default (opts = {}) => ({
   },
   renderNode: (props, editor, next) => {
     const { node } = props
+    if (node.type !== 'jsx-void') return next()
+    const component = node.data.get('type')
 
-    switch (node.type) {
-      case 'youtube':
+    switch (component) {
+      case 'YouTube':
         return <YouTube {...props} editor={editor} props={getProps(node)} />
         break
-      case 'gist':
+      case 'Gist':
         return <Gist {...props} editor={editor} props={getProps(node)} />
         break
       default:

--- a/packages/serializer/src/index.js
+++ b/packages/serializer/src/index.js
@@ -327,15 +327,9 @@ const jsxMark = {
   }
 }
 
-const jsxBlockTypes = {
-  youtube: '<YouTube />',
-  gist: '<Gist />',
-  TomatoBox: '<TomatoBox />'
-}
 const isJSX = node => {
   if (node.object !== 'block') return false
-  if (node.type === 'jsx') return true
-  return !!jsxBlockTypes[node.type]
+  return node.type === 'jsx' || node.type === 'jsx-void'
 }
 
 const jsxBlock = {
@@ -349,72 +343,33 @@ const jsxBlock = {
         type: getComponentName(node.children[0].value),
         props: {}
       }
+      return {
+        object: 'block',
+        type: 'jsx',
+        nodes: visitChildren(node),
+        data: {
+          type: data.type,
+          props: Data.create(data.props)
+        }
+      }
     } else {
       data = parseJSXBlock(node.value)
-    }
-
-    switch (data.type) {
-      case 'YouTube':
-        return {
-          object: 'block',
-          type: 'youtube',
-          data: {
-            type: data.type,
-            props: Data.create(data.props || {})
-          }
+      return {
+        object: 'block',
+        type: 'jsx-void',
+        data: {
+          type: data.type,
+          props: Data.create(data.props)
         }
-      case 'Gist':
-        return {
-          object: 'block',
-          type: 'gist',
-          data: {
-            type: data.type,
-            props: Data.create(data.props || {})
-          }
-        }
-      default:
-        // This is an interleaved block so we handle it specially since
-        // we want to walk its children and create a wrapping block.
-        if (node.children) {
-          return {
-            object: 'block',
-            type: data.type,
-            nodes: visitChildren(node),
-            data: {
-              type: data.type,
-              props: Data.create(data.props || {})
-            }
-          }
-        }
-
-        return {
-          object: 'block',
-          type: 'jsx',
-          data: {
-            type: data.type,
-            props: data.props
-          },
-          nodes: [
-            {
-              object: 'text',
-              leaves: [
-                {
-                  object: 'leaf',
-                  text: node.value,
-                  marks: []
-                }
-              ]
-            }
-          ]
-        }
+      }
     }
   },
   toMdast: (object, index, parent, { visitChildren }) => {
     let value = object.nodes.map(node => node.leaves[0].text).join()
-    if (jsxBlockTypes[object.type]) {
+    if (object.type === 'jsx-void') {
       // only update blessed types
-      value = jsxBlockTypes[object.type]
-      const props = object.data.props.toJS()
+      value = `<${object.data.type} />`
+      const props = object.data.props
       value = applyProps(value, { props })
     }
     return {


### PR DESCRIPTION
This is just a rough demonstration of using generic JSX block types for built-in and custom blocks

- Added a `jsx-void` type for JSX components without children
- Removed custom block types for `youtube` & `gist`
- The JSX blocks plugin renders based on `block.data.type` and passes on to `next()` - this check could be done based on the `components` passed in to the Editor component
- The forms are still custom for gist and youtube block types, but that could be dynamic and DRYed up