### PR TITLE
Fix initial props handling

### DIFF
--- a/packages/serializer/src/index.js
+++ b/packages/serializer/src/index.js
@@ -6,7 +6,7 @@ const remarkSqueezeParagraphs = require('remark-squeeze-paragraphs')
 const mdx = require('remark-mdx')
 const { Data } = require('slate')
 
-const { getComponentName } = require('./util')
+const { getComponentName, toJS } = require('./util')
 const { parseJSXBlock, applyProps } = require('./parse-jsx')
 const remarkInterleave = require('./remark-interleave').default
 
@@ -369,7 +369,7 @@ const jsxBlock = {
     }
   },
   toMdast: (object, index, parent, { visitChildren }) => {
-    const props = object.data.props
+    const props = toJS(object.data.props)
 
     if (!object.data.type) {
       return {

--- a/packages/serializer/src/util.js
+++ b/packages/serializer/src/util.js
@@ -6,3 +6,8 @@ export const getComponentName = (str = '') => {
   const match = str.match(/^\<?([\w\.\_]+)/)
   return match && match[1]
 }
+
+export const toJS = map => {
+  if (typeof map.toJS !== 'function') return map
+  return map.toJS()
+}

--- a/packages/serializer/test/__snapshots__/serializer.test.js.snap
+++ b/packages/serializer/test/__snapshots__/serializer.test.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`correctly passes props in JSX blocks 1`] = `
+Object {
+  "document": Object {
+    "data": Object {},
+    "nodes": Array [
+      Object {
+        "data": Object {
+          "props": Immutable.Map {
+            "id": "1234",
+          },
+          "type": "YouTube",
+        },
+        "nodes": Array [],
+        "object": "block",
+        "type": "jsx-void",
+      },
+    ],
+    "object": "document",
+  },
+  "object": "value",
+}
+`;
+
 exports[`correctly serializes MDX to Slate schema 1`] = `
 Object {
   "document": Object {
@@ -75,7 +98,7 @@ Object {
           },
         ],
         "object": "block",
-        "type": "Block",
+        "type": "jsx",
       },
       Object {
         "data": Object {},

--- a/packages/serializer/test/serializer.test.js
+++ b/packages/serializer/test/serializer.test.js
@@ -19,3 +19,9 @@ test('correctly serializes MDX to Slate schema', () => {
 
   expect(result.toJSON()).toMatchSnapshot()
 })
+
+test('correctly passes props in JSX blocks', () => {
+  const result = serializer.deserialize(parseMDX('<YouTube id="1234" />'))
+
+  expect(result.toJSON()).toMatchSnapshot()
+})


### PR DESCRIPTION
When initialized, the props passed for serialization are
an immutable js map but all subsequent props values are
standard js objects. To keep things simple let's ensure
all maps are coerced into vanilla js objects.

Fixes #20