### PR TITLE
WIP: split view editor

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -18,8 +18,8 @@ const initialValue =
 export default () => (
   <div
     css={{
-      maxWidth: '48em',
-      padding: 32,
+      maxWidth: '80vw',
+      padding: '2em 0',
       marginLeft: 'auto',
       marginRight: 'auto'
     }}

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^10.0.10",
     "@material-ui/core": "^3.9.3",
     "@material-ui/icons": "^3.0.2",
+    "@mdx-js/runtime": "^1.0.18",
     "@reach/alert-dialog": "^0.2.3",
     "@reach/menu-button": "^0.1.17",
     "@slate-editor/utils": "^5.1.0",

--- a/packages/editor/src/components/Editor.js
+++ b/packages/editor/src/components/Editor.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react'
 import { Editor, getEventRange, getEventTransfer } from 'slate-react'
 import { ThemeProvider } from 'theme-ui'
+import MDX from '@mdx-js/runtime'
 
 import schema from '../lib/schema'
 import initialValue from '!!raw-loader!../lib/value.mdx'
-import { parseMDX, serializer } from '@blocks/serializer'
+import { parseMDX, serializer, stringifyMDX } from '@blocks/serializer'
 import { isUrl, isImageUrl } from '../lib/util'
 
 import { Context } from './context'
@@ -103,6 +104,7 @@ class BlockEditor extends Component {
 
   render() {
     const { plugins, theme, components } = this.props
+    const { value } = this.state
     const allComponents = {
       ...defaultBlocks,
       ...components
@@ -111,23 +113,43 @@ class BlockEditor extends Component {
       components: allComponents
     }
 
+    const result = stringifyMDX(serializer.serialize(value))
+
     return (
-      <div style={{ minHeight: '100vh' }}>
-        <Context.Provider value={context}>
-          <Editor
-            {...this.props}
-            ref={editor => (this.editor = editor)}
-            components={allComponents}
-            theme={theme}
-            schema={schema}
-            placeholder="Write some MDX..."
-            plugins={plugins}
-            value={this.state.value}
-            onChange={this.handleChange}
-            onKeyDown={this.handleKeyDown}
-            onPaste={this.handlePaste}
-          />
-        </Context.Provider>
+      <div style={{ minHeight: '100vh', display: 'flex' }}>
+        <div
+          style={{
+            flex: '0 0 50%',
+            border: '3px solid grey',
+            padding: '1em',
+            borderRight: 'none'
+          }}
+        >
+          <Context.Provider value={context}>
+            <Editor
+              {...this.props}
+              ref={editor => (this.editor = editor)}
+              components={allComponents}
+              theme={theme}
+              schema={schema}
+              placeholder="Write some MDX..."
+              plugins={plugins}
+              value={this.state.value}
+              onChange={this.handleChange}
+              onKeyDown={this.handleKeyDown}
+              onPaste={this.handlePaste}
+            />
+          </Context.Provider>
+        </div>
+        <div
+          style={{
+            flex: '0 0 50%',
+            border: '3px solid grey',
+            padding: '1em'
+          }}
+        >
+          <MDX components={allComponents}>{result}</MDX>
+        </div>
       </div>
     )
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,6 +1787,27 @@
     unist-builder "^1.0.1"
     unist-util-visit "^1.3.0"
 
+"@mdx-js/mdx@^1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.0.18.tgz#42bb35e36b7566aed88c5c11a381705f974bc03b"
+  integrity sha512-KO2odMrZC77Yf9bhL0Qu0GtvVivVV6dL5DWJeuMeSkc9wkL9fBT06re67TfgeJ37R+lyslkG+uPUahIj4/SOoQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-jsx" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    change-case "^3.0.2"
+    detab "^2.0.0"
+    hast-util-raw "^5.0.0"
+    lodash.uniq "^4.5.0"
+    mdast-util-to-hast "^4.0.0"
+    remark-mdx "^1.0.18"
+    remark-parse "^6.0.0"
+    remark-squeeze-paragraphs "^3.0.1"
+    to-style "^1.3.3"
+    unified "^7.0.0"
+    unist-builder "^1.0.1"
+    unist-util-visit "^1.3.0"
+
 "@mdx-js/react@^1.0.15", "@mdx-js/react@^1.0.16", "@mdx-js/react@^1.0.6":
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-1.0.16.tgz#414c3fce49493a4c60e5590cfc0a2a07efc19f38"
@@ -1798,6 +1819,15 @@
   integrity sha512-8ZoC5pju5bUmATiSMwVgCR3/Fpa/Inw+sSqZRlbgSXz/4RpLP2w6OF2u7M5VB/Kab1GXi5kC6Z/qlSNGxTqVfQ==
   dependencies:
     "@mdx-js/mdx" "^1.0.16"
+    "@mdx-js/react" "^1.0.16"
+    buble "^0.19.6"
+
+"@mdx-js/runtime@^1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@mdx-js/runtime/-/runtime-1.0.18.tgz#1e6e69473e60ccc94007a67dcc475e60f797a8bd"
+  integrity sha512-uh2aHOYJCHADvHrcVvo+P71dv3h44Mtl6X8Pfn02MWfjWuzE5VQ0SvwgMBmxou1DZP8ogJkXGjsc49YulWzMrA==
+  dependencies:
+    "@mdx-js/mdx" "^1.0.18"
     "@mdx-js/react" "^1.0.16"
     buble "^0.19.6"
 
@@ -12472,6 +12502,19 @@ remark-mdx@^1.0.15:
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-1.0.15.tgz#6f2de2dcf3b94d5ed027d4140e1bd9c748c26a73"
   integrity sha512-X9nQjfHLettXJ+DqIzHwLU6sIVFCjseJlCyaNsLVrIIRqxRcwm4MKifw1jcHa1Rb+uBf1CxJX2B/+qI9X2QAmA==
+  dependencies:
+    "@babel/core" "^7.2.2"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.3.2"
+    "@babel/plugin-syntax-jsx" "^7.2.0"
+    is-alphabetical "^1.0.2"
+    remark-parse "^6.0.0"
+    unified "^7.0.0"
+
+remark-mdx@^1.0.18:
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-1.0.18.tgz#a686bcb1166ae673bc77d9e459dbd576443bf854"
+  integrity sha512-PLsY2LNXuJ8YHaxjuOpRk+hDviB7jBFwLmLN4m4P5/Ev+NlmG8uXisAkP4P4Al47CPmJyKHQRJMjA8mWu4exVw==
   dependencies:
     "@babel/core" "^7.2.2"
     "@babel/helper-plugin-utils" "^7.0.0"


### PR DESCRIPTION
A quick hack already gave me some awesome results. No scroll sync yet, but thanks to the [mdx runtime](https://mdxjs.com/advanced/runtime) a split view with preview was no effort at all.

The total bundle size of the editor is already huge, the runtime does not really add much:

### Current bundle:
![Screenshot 2019-05-11 at 19 41 01](https://user-images.githubusercontent.com/1737026/57573247-15364180-7425-11e9-8d08-e4b21c862ee0.png)

### Bundle with mdx/runtime:
![Screenshot 2019-05-11 at 19 41 08](https://user-images.githubusercontent.com/1737026/57573248-15ced800-7425-11e9-8038-05eefb50e55f.png)

Results as html files if somebody is curious: [webpack-bundle-analyzer.zip](https://github.com/blocks/blocks/files/3169318/webpack-bundle-analyzer.zip)


## Still open:
* scroll sync
* option to show JSX instead of WYSIWYG

## Try it out on your own:
👉https://axe312ger.github.io/blocks/