### PR TITLE
Update link of Johno's "authorable" article

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ And a GitHub Gist:
 
 [mdx]: https://mdxjs.com/
 [npm]: https://npmjs.com/
-[authorable]: https://johno.com/authorable
+[authorable]: https://johno.com/authorable-format


### PR DESCRIPTION
Currently following the link of "Authorable", you see this:

![image](https://user-images.githubusercontent.com/1705507/63936468-8ea37f80-ca68-11e9-971a-355bfe1ce748.png)

Digging the page I found the article to be under a new URL, appending `-format`.