### PR TITLE
fix(ui): Remove icon background in Safari

### DIFF
--- a/packages/blocks-ui/src/ui.js
+++ b/packages/blocks-ui/src/ui.js
@@ -4,6 +4,7 @@ import { jsx } from 'theme-ui'
 export const IconButton = props => (
   <button
     sx={{
+      background: 'none',
       appearance: 'none',
       border: 0,
       px: 2,


### PR DESCRIPTION
I noticed that in Safari, you have this weird background color with all of the icons in the site:

![Shot 2019-11-26 at 08 46 58](https://user-images.githubusercontent.com/30328854/69619899-49c1c180-1034-11ea-8a08-0dedd2609839.jpg)

This PR is a quick fix to this issue:

![Shot 2019-11-26 at 10 04 36](https://user-images.githubusercontent.com/30328854/69619917-5219fc80-1034-11ea-933d-08f134f54454.jpg)