### PR TITLE
fix(ui): Change code color to black

### DIFF
--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -28,7 +28,8 @@ export default ({ code, transformedCode, scope, theme }) => {
           language="js"
           sx={{
             mt: 0,
-            backgroundColor: 'white'
+            backgroundColor: 'white',
+            color: 'black'
           }}
         >
           {prettier.format(code, {


### PR DESCRIPTION
@johno has forced the background in the code view to be white. Thus, I have adjusted the code color to black so that it doesn't inherit it from the current theme.

![Shot 2019-11-26 at 10 34 32](https://user-images.githubusercontent.com/30328854/69622492-eede9900-1038-11ea-9e48-de4109660442.jpg)

Fixes #73