### PR TITLE
feat: Don't unselect when deleting element

### DIFF
--- a/packages/blocks-ui/src/index.js
+++ b/packages/blocks-ui/src/index.js
@@ -181,7 +181,11 @@ export default ({ src: initialCode, blocks: providedBlocks, onChange }) => {
   const handleRemoveElement = () => {
     const { code: newCode } = transforms.removeElement(code, { elementId })
     setCode(newCode)
-    setElementId(null)
+    if (elementData.parentId) {
+      setElementId(elementData.parentId)
+    } else {
+      setElementId(null)
+    }
     setElementData(null)
   }
 


### PR DESCRIPTION
This PR makes sure that when deleting components, the selection state is maintained.

I have marked this as a draft PR, as when trying to delete an entire block (instead of just a component), the UI crashes. This is the same behaviour to what was described in https://github.com/blocks/blocks/issues/59#issuecomment-558517858.

Closes #71