### PR TITLE
fix(ui): Change input background color to white

### DIFF
--- a/packages/blocks-ui/src/property-controls-panel.js
+++ b/packages/blocks-ui/src/property-controls-panel.js
@@ -75,14 +75,22 @@ export default ({
               return (
                 <div className="fieldset" key={key}>
                   <Label>{title}</Label>
-                  <Input value={elementData.text} onChange={onTextChange} />
+                  <Input
+                    sx={{ backgroundColor: 'white' }}
+                    value={elementData.text}
+                    onChange={onTextChange}
+                  />
                 </div>
               )
             } else if (value.type === ControlType.String) {
               return (
                 <div className="fieldset" key={key}>
                   <Label>{title}</Label>
-                  <Input value={fieldValue} onChange={onPropChange(key)} />
+                  <Input
+                    sx={{ backgroundColor: 'white' }}
+                    value={fieldValue}
+                    onChange={onPropChange(key)}
+                  />
                 </div>
               )
             } else if (value.type === ControlType.Number) {
@@ -90,6 +98,7 @@ export default ({
                 <div className="fieldset" key={key}>
                   <Label>{title}</Label>
                   <Input
+                    sx={{ backgroundColor: 'white' }}
                     type="number"
                     value={fieldValue}
                     onChange={onPropChange(key)}

--- a/packages/blocks-ui/src/tree-view.js
+++ b/packages/blocks-ui/src/tree-view.js
@@ -32,10 +32,10 @@ export default ({ children, onSelect }) => {
           onClick={() => onSelect(c.id)}
           sx={{
             fontSize: 1,
-            color: 'inherit',
+            // color: 'black',
             textDecoration: 'none',
             appearance: 'none',
-            backgroundColor: 'background',
+            backgroundColor: 'white',
             borderRadius: 4,
             border: 'thin solid #e1e6eb',
             display: 'block',


### PR DESCRIPTION
In the site, the background of the input boxes are inherited from the current theme:

![Shot 2019-11-26 at 14 56 22](https://user-images.githubusercontent.com/30328854/69644738-f1eb8080-105c-11ea-90b4-c0b33fdb9d52.jpg)

This PR fixes this issue:

![Shot 2019-11-26 at 14 57 47](https://user-images.githubusercontent.com/30328854/69644853-2101f200-105d-11ea-973c-819059d4d24a.jpg)
