### PR TITLE
Docs: Add custom 404 page

### DIFF
--- a/src/pages/404.mdx
+++ b/src/pages/404.mdx
@@ -1,0 +1,10 @@
+---
+title: Error
+---
+
+import Layout from '../components/minimal-layout'
+export default Layout
+
+# Error: Page not found
+
+[Head back to the homepage](/)


### PR DESCRIPTION
Adds a simple custom 404 page so users don't see the default from ZEIT