### PR TITLE
Add Carte Blanche to prior art

### DIFF
--- a/src/pages/prior-art.mdx
+++ b/src/pages/prior-art.mdx
@@ -18,5 +18,6 @@ have provided inspiration in one way or another. Below begins a list
 - **Webflow**: #nocode
 - **Gutenberg**: What's likely _the_ most popular block editor and ecosystem
 - **Alva**: React component-based WYSIWYG
+- **Carte Blanche**: Isolated development space for components
 
 Is your project missing? Please [open up a PR](https://github.com/blocks/blocks).


### PR DESCRIPTION
[Carte Blanche](https://github.com/carteb/carte-blanche) is a project `@nikgraf` and I worked on back in 2017 that aimed to create "an automatic Storybook" before Storybook was really a big thing.

It automatically analyzed your source code, detected any React components and their props (based on PropTypes) and rendered them in an isolated development space where you could quickly see many iterations of the component based on rendering them with different props. It also had built-in fuzzy testing, where it would input random strange props that were e.g. really long, really short, had strange characters, etc.

![](https://cloud.githubusercontent.com/assets/7525670/15761445/8ae05d4a-2918-11e6-8573-bd9bd0ef2330.png)

The important bit is that it was fully automatic, you did not have to manually create anything like "Stories". It was supposed to just work :tm: with a single command.

We never got it to a state where it was easily usable and ran into some fundamental issues with the automatic detection that seems insurmountable, so we lost steam and eventually stopped working on it altogether. You can see a demo of all the features we did build here: https://www.youtube.com/watch?v=6g3-TQ6aaw8