### PR TITLE
feat: Add ability to copy code to clipboard

### DIFF
--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -24,41 +24,44 @@ const Wrap = props => (
 )
 
 function copyToClipboard(toCopy) {
-  const el = document.createElement(`textarea`);
-  el.value = toCopy;
-  el.setAttribute(`readonly`, ``);
-  el.style.position = `absolute`;
-  el.style.left = `-9999px`;
-  document.body.appendChild(el);
-  el.select();
-  document.execCommand(`copy`);
-  document.body.removeChild(el);
+  const el = document.createElement(`textarea`)
+  el.value = toCopy
+  el.setAttribute(`readonly`, ``)
+  el.style.position = `absolute`
+  el.style.left = `-9999px`
+  document.body.appendChild(el)
+  el.select()
+  document.execCommand(`copy`)
+  document.body.removeChild(el)
 }
 
 const Copy = ({ toCopy }) => {
-  const [hasCopied, setHasCopied] = useState(false);
+  const [hasCopied, setHasCopied] = useState(false)
 
   function copyToClipboardOnClick() {
-    if (hasCopied) return;
+    if (hasCopied) return
 
-    copyToClipboard(toCopy);
-    setHasCopied(true);
+    copyToClipboard(toCopy)
+    setHasCopied(true)
 
     setTimeout(() => {
-      setHasCopied(false);
-    }, 2000);
+      setHasCopied(false)
+    }, 2000)
   }
 
   return (
-    <IconButton onClick={copyToClipboardOnClick} sx={{ position: 'absolute', right: 0 }}>
+    <IconButton
+      onClick={copyToClipboardOnClick}
+      sx={{ position: 'absolute', right: 0 }}
+    >
       {hasCopied ? (
-        <Check sx={{ color: "green" }} aria-label="Copied" />
+        <Check sx={{ color: 'green' }} aria-label="Copied" />
       ) : (
         <Clipboard aria-label="Copy" />
       )}
     </IconButton>
-  );
-};
+  )
+}
 
 export default ({ code, transformedCode, scope, theme }) => {
   const { mode } = useEditor()

--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -52,11 +52,11 @@ const Copy = ({ toCopy }) => {
     <IconButton onClick={copyToClipboardOnClick}>
       {hasCopied ? (
         <>
-          <Check sx={{ color: "green" }} />
+          <Check sx={{ color: "green" }} aria-label="Copied" />
         </>
       ) : (
         <>
-          <Clipboard />
+          <Clipboard aria-label="Copy" />
         </>
       )}
     </IconButton>

--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -49,7 +49,7 @@ const Copy = ({ toCopy }) => {
   }
 
   return (
-    <IconButton onClick={copyToClipboardOnClick}>
+    <IconButton onClick={copyToClipboardOnClick} sx={{ float: "right" }}>
       {hasCopied ? (
         <>
           <Check sx={{ color: "green" }} aria-label="Copied" />

--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -13,6 +13,7 @@ import { IconButton } from './ui'
 const Wrap = props => (
   <div
     sx={{
+      position: 'relative',
       width: '60%',
       backgroundColor: 'white',
       height: 'calc(100vh - 41px)',
@@ -49,15 +50,11 @@ const Copy = ({ toCopy }) => {
   }
 
   return (
-    <IconButton onClick={copyToClipboardOnClick} sx={{ float: "right" }}>
+    <IconButton onClick={copyToClipboardOnClick} sx={{ position: 'absolute', right: 0 }}>
       {hasCopied ? (
-        <>
-          <Check sx={{ color: "green" }} aria-label="Copied" />
-        </>
+        <Check sx={{ color: "green" }} aria-label="Copied" />
       ) : (
-        <>
-          <Clipboard aria-label="Copy" />
-        </>
+        <Clipboard aria-label="Copy" />
       )}
     </IconButton>
   );
@@ -65,14 +62,15 @@ const Copy = ({ toCopy }) => {
 
 export default ({ code, transformedCode, scope, theme }) => {
   const { mode } = useEditor()
+  const formattedCode = prettier.format(code, {
+    parser: 'babel',
+    plugins: [parserJS]
+  })
 
   if (mode === 'code') {
     return (
       <Wrap>
-        <Copy toCopy={prettier.format(code, {
-          parser: 'babel',
-          plugins: [parserJS]
-        })} />
+        <Copy toCopy={formattedCode} />
         <Styled.pre
           language="js"
           sx={{
@@ -81,10 +79,7 @@ export default ({ code, transformedCode, scope, theme }) => {
             color: 'black'
           }}
         >
-          {prettier.format(code, {
-            parser: 'babel',
-            plugins: [parserJS]
-          })}
+          {formattedCode}
         </Styled.pre>
       </Wrap>
     )

--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -1,10 +1,13 @@
 /** @jsx jsx */
+import React, { useState } from 'react'
 import { jsx, Styled } from 'theme-ui'
 import prettier from 'prettier/standalone'
 import parserJS from 'prettier/parser-babylon'
 
 import { useEditor } from './editor-context'
 import InlineRender from './inline-render'
+
+import { Clipboard, Check } from 'react-feather'
 
 const Wrap = props => (
   <div
@@ -17,6 +20,47 @@ const Wrap = props => (
     {...props}
   />
 )
+
+function copyToClipboard(toCopy) {
+  const el = document.createElement(`textarea`);
+  el.value = toCopy;
+  el.setAttribute(`readonly`, ``);
+  el.style.position = `absolute`;
+  el.style.left = `-9999px`;
+  document.body.appendChild(el);
+  el.select();
+  document.execCommand(`copy`);
+  document.body.removeChild(el);
+}
+
+const Copy = ({ toCopy }) => {
+  const [hasCopied, setHasCopied] = useState(false);
+
+  function copyToClipboardOnClick() {
+    if (hasCopied) return;
+
+    copyToClipboard(toCopy);
+    setHasCopied(true);
+
+    setTimeout(() => {
+      setHasCopied(false);
+    }, 2000);
+  }
+
+  return (
+    <button onClick={copyToClipboardOnClick}>
+      {hasCopied ? (
+        <>
+          <Check />
+        </>
+      ) : (
+        <>
+          <Clipboard />
+        </>
+      )}
+    </button>
+  );
+};
 
 export default ({ code, transformedCode, scope, theme }) => {
   const { mode } = useEditor()
@@ -37,6 +81,10 @@ export default ({ code, transformedCode, scope, theme }) => {
             plugins: [parserJS]
           })}
         </Styled.pre>
+        <Copy toCopy={prettier.format(code, {
+          parser: 'babel',
+          plugins: [parserJS]
+        })} />
       </Wrap>
     )
   }

--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -8,6 +8,7 @@ import { useEditor } from './editor-context'
 import InlineRender from './inline-render'
 
 import { Clipboard, Check } from 'react-feather'
+import { IconButton } from './ui'
 
 const Wrap = props => (
   <div
@@ -48,17 +49,17 @@ const Copy = ({ toCopy }) => {
   }
 
   return (
-    <button onClick={copyToClipboardOnClick}>
+    <IconButton onClick={copyToClipboardOnClick}>
       {hasCopied ? (
         <>
-          <Check />
+          <Check sx={{ color: "green" }} />
         </>
       ) : (
         <>
           <Clipboard />
         </>
       )}
-    </button>
+    </IconButton>
   );
 };
 
@@ -68,6 +69,10 @@ export default ({ code, transformedCode, scope, theme }) => {
   if (mode === 'code') {
     return (
       <Wrap>
+        <Copy toCopy={prettier.format(code, {
+          parser: 'babel',
+          plugins: [parserJS]
+        })} />
         <Styled.pre
           language="js"
           sx={{
@@ -81,10 +86,6 @@ export default ({ code, transformedCode, scope, theme }) => {
             plugins: [parserJS]
           })}
         </Styled.pre>
-        <Copy toCopy={prettier.format(code, {
-          parser: 'babel',
-          plugins: [parserJS]
-        })} />
       </Wrap>
     )
   }


### PR DESCRIPTION
I noticed that in the code view, it is inefficient to select the code and then copy it. So, I have added a handy button that copies the code for you 😄

I am battling with some CSS issues right now, but the end goal is the have the button on the right, not the left.