### PR TITLE
Do not show scroll bars for editor and side panel unless necessary

### DIFF
--- a/packages/blocks-ui/src/babel-plugins/inject-blocks-root.js
+++ b/packages/blocks-ui/src/babel-plugins/inject-blocks-root.js
@@ -8,7 +8,7 @@ const root = template.ast(
         {(provided, snapshot) => (
           <div
             {...provided.droppableProps}
-            style={{ minHeight: 'calc(100vh - 41px)' }}
+            style={{ minHeight: 'calc(100vh - 43px)' }}
             ref={provided.innerRef}
           >
             {children}

--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -11,8 +11,8 @@ const Wrap = props => (
     sx={{
       width: '60%',
       backgroundColor: 'white',
-      height: 'calc(100vh - 41px)',
-      overflow: 'scroll'
+      height: 'calc(100vh - 43px)',
+      overflow: 'auto'
     }}
     {...props}
   />

--- a/packages/blocks-ui/src/editor-panel.js
+++ b/packages/blocks-ui/src/editor-panel.js
@@ -39,7 +39,7 @@ export default ({
     <div
       sx={{
         height: '100vh',
-        overflow: 'scroll'
+        overflow: 'auto'
       }}
     >
       <Flex

--- a/packages/blocks-ui/src/side-panel.js
+++ b/packages/blocks-ui/src/side-panel.js
@@ -32,8 +32,8 @@ export default ({
     sx={{
       borderLeft: 'thin solid #e1e6eb',
       width: '40%',
-      height: 'calc(100vh - 41px)',
-      overflow: 'scroll',
+      height: 'calc(100vh - 43px)',
+      overflow: 'auto',
       pb: 3
     }}
   >


### PR DESCRIPTION
I noticed that there were always at least 2 scroll bars visible, even if they didn't need to be. In this PR I only show them when necessary.

I've also updated a few instances of 41px to 43px as that is the height of the header.

Before

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/3044853/69740294-157ffb00-1131-11ea-909a-ca069e65a8be.png">

After

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/3044853/69740360-292b6180-1131-11ea-85c3-a0c13f338aa4.png">

