### PR TITLE
Sticky the tab list so it is always visible

### DIFF
--- a/packages/blocks-ui/src/side-panel.js
+++ b/packages/blocks-ui/src/side-panel.js
@@ -41,7 +41,9 @@ export default ({
       <TabList
         sx={{
           display: 'flex',
-          width: '100%'
+          width: '100%',
+          position: 'sticky',
+          top: 0
         }}
       >
         <Tab


### PR DESCRIPTION
Really small change to always show the editor/components/theme tab list :D

<img width="665" alt="image" src="https://user-images.githubusercontent.com/3044853/69741320-c2a74300-1132-11ea-9ed0-e990e39c8828.png">
