### PR TITLE
Add theme editor

### DIFF
--- a/packages/blocks-ui/package.json
+++ b/packages/blocks-ui/package.json
@@ -17,6 +17,7 @@
     "@theme-ui/components": "^0.2.49",
     "@theme-ui/editor": "^0.2.49",
     "@theme-ui/presets": "^0.2.44",
+    "lodash.merge": "^4.6.2",
     "prettier": "^1.19.1",
     "property-controls": "^0.0.39",
     "react-beautiful-dnd": "^12.1.1",

--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-import React, { useState } from 'react'
 import { jsx, Styled } from 'theme-ui'
 import prettier from 'prettier/standalone'
 import parserJS from 'prettier/parser-babylon'
@@ -9,6 +8,7 @@ import InlineRender from './inline-render'
 
 import { Clipboard, Check } from 'react-feather'
 import { IconButton } from './ui'
+import useCopyToClipboard from './use-copy-to-clipboard'
 
 const Wrap = props => (
   <div
@@ -23,35 +23,12 @@ const Wrap = props => (
   />
 )
 
-function copyToClipboard(toCopy) {
-  const el = document.createElement(`textarea`)
-  el.value = toCopy
-  el.setAttribute(`readonly`, ``)
-  el.style.position = `absolute`
-  el.style.left = `-9999px`
-  document.body.appendChild(el)
-  el.select()
-  document.execCommand(`copy`)
-  document.body.removeChild(el)
-}
-
 const Copy = ({ toCopy }) => {
-  const [hasCopied, setHasCopied] = useState(false)
-
-  function copyToClipboardOnClick() {
-    if (hasCopied) return
-
-    copyToClipboard(toCopy)
-    setHasCopied(true)
-
-    setTimeout(() => {
-      setHasCopied(false)
-    }, 2000)
-  }
+  const { hasCopied, copyToClipboard } = useCopyToClipboard()
 
   return (
     <IconButton
-      onClick={copyToClipboardOnClick}
+      onClick={() => copyToClipboard(toCopy)}
       sx={{ position: 'absolute', right: '-4px' }}
     >
       {hasCopied ? (

--- a/packages/blocks-ui/src/index.js
+++ b/packages/blocks-ui/src/index.js
@@ -79,11 +79,10 @@ export default ({ src: initialCode, blocks: providedBlocks, onChange }) => {
   const [elementId, setElementId] = useState(null)
   const [elementData, setElementData] = useState(null)
   const [activeTab, setActiveTab] = useState(0)
-  const [themeName, setThemeName] = useState('system')
   const [srcBlocks, setSrcBlocks] = useState([])
+  const [theme, setTheme] = useState(presets.system)
 
   const blocks = providedBlocks ? providedBlocks : DEFAULT_BLOCKS
-  const theme = presets[themeName]
 
   const scope = {
     Blocks: DEFAULT_BLOCKS.Blocks,
@@ -248,8 +247,6 @@ export default ({ src: initialCode, blocks: providedBlocks, onChange }) => {
     setCode(newCode)
   }
 
-  console.log(elementData)
-
   return (
     <Layout elementData={elementData} theme={appTheme}>
       <Header />
@@ -274,7 +271,7 @@ export default ({ src: initialCode, blocks: providedBlocks, onChange }) => {
             blocks={blocks}
             srcBlocks={srcBlocks}
             theme={theme}
-            themeName={themeName}
+            setTheme={setTheme}
             elementData={elementData}
             handleChange={handleChange}
             handlePropChange={handlePropChange}
@@ -284,7 +281,6 @@ export default ({ src: initialCode, blocks: providedBlocks, onChange }) => {
             handleInsertElement={handleInsertElement}
             handleClone={handleClone}
             handleTextUpdate={handleTextUpdate}
-            setThemeName={setThemeName}
             setElementId={setElementId}
           />
         </div>

--- a/packages/blocks-ui/src/side-panel.js
+++ b/packages/blocks-ui/src/side-panel.js
@@ -1,5 +1,4 @@
 /** @jsx jsx */
-import React from 'react'
 import { jsx } from 'theme-ui'
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@reach/tabs'
 
@@ -14,7 +13,7 @@ export default ({
   blocks,
   srcBlocks,
   theme,
-  themeName,
+  setTheme,
   elementData,
   handleChange,
   handlePropChange,
@@ -24,7 +23,6 @@ export default ({
   handleInsertElement,
   handleClone,
   handleTextUpdate,
-  setThemeName,
   setElementId
 }) => (
   <section
@@ -150,7 +148,7 @@ export default ({
           ) : null}
         </TabPanel>
         <TabPanel>
-          <ThemePanel themeName={themeName} setThemeName={setThemeName} />
+          <ThemePanel theme={theme} setTheme={setTheme} />
         </TabPanel>
       </TabPanels>
     </Tabs>

--- a/packages/blocks-ui/src/theme-panel.js
+++ b/packages/blocks-ui/src/theme-panel.js
@@ -1,29 +1,105 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import { useState } from 'react'
 import * as presets from '@theme-ui/presets'
-import { Box, Heading, Label, Select } from '@theme-ui/components'
+import { Box, Heading, Label, Select, Button } from '@theme-ui/components'
+import {
+  Editor,
+  Row,
+  Fonts,
+  FontSizes,
+  FontWeights,
+  LineHeights,
+  ColorMode,
+  ColorPalette,
+  Space
+} from '@theme-ui/editor'
+import merge from 'lodash.merge'
+import useCopyToClipboard from './use-copy-to-clipboard'
 
 const themes = Object.keys(presets)
 const options = themes.map(name => <option key={name} children={name} />)
 
-export default ({ themeName, setThemeName }) => {
-  const onSubmit = e => {
-    e.preventDefault()
-  }
+export default ({ theme, setTheme }) => {
+  const [customiseTheme, setCustomiseTheme] = useState(false)
+  const { hasCopied, copyToClipboard } = useCopyToClipboard()
 
   return (
     <Box p={3}>
-      <Heading>Theme</Heading>
-      <form onSubmit={onSubmit}>
-        <Label htmlFor="preset">Preset</Label>
-        <Select
-          value={themeName}
-          onChange={e => {
-            setThemeName(e.target.value)
-          }}
-          children={options}
-        />
-      </form>
+      <Heading mb={3}>Theme</Heading>
+      <ThemePresetForm theme={theme} setTheme={setTheme} />
+      {customiseTheme && <ThemeEditor theme={theme} setTheme={setTheme} />}
+      <Box mt={3}>
+        <Button sx={{ mr: 2 }} onClick={() => setCustomiseTheme(c => !c)}>
+          {customiseTheme ? 'Close' : 'Customise Theme'}
+        </Button>
+        {customiseTheme && (
+          <Button
+            variant="secondary"
+            onClick={() => copyToClipboard(JSON.stringify(theme))}
+          >
+            {hasCopied ? 'Copied' : 'Copy'} Theme
+          </Button>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+const ThemePresetForm = ({ setTheme }) => {
+  const [themeName, setThemeName] = useState('system')
+
+  const onPresetChange = e => {
+    const presetKey = e.target.value
+    setTheme(currentTheme => merge({}, currentTheme, presets[presetKey]))
+    setThemeName(presetKey)
+  }
+
+  const onSubmit = e => e.preventDefault()
+
+  return (
+    <Box as="form" mb={3} onSubmit={onSubmit}>
+      <Label htmlFor="preset">Theme UI Preset</Label>
+      <Select
+        id="preset"
+        name="preset"
+        value={themeName}
+        onChange={onPresetChange}
+        children={options}
+      />
+    </Box>
+  )
+}
+
+const ThemeEditor = ({ theme, setTheme }) => {
+  const context = {
+    theme,
+    setTheme(nextTheme) {
+      setTheme(currentTheme => merge({}, currentTheme, nextTheme))
+    }
+  }
+  return (
+    <Box>
+      <Heading as="h3" mb={2}>
+        Theme Editor
+      </Heading>
+      <Editor context={context}>
+        <Fonts />
+        <Row>
+          <FontSizes />
+        </Row>
+        <Row>
+          <FontWeights />
+        </Row>
+        <Row>
+          <LineHeights />
+        </Row>
+        <ColorMode />
+        <ColorPalette />
+        <Row>
+          <Space />
+        </Row>
+      </Editor>
     </Box>
   )
 }

--- a/packages/blocks-ui/src/use-copy-to-clipboard.js
+++ b/packages/blocks-ui/src/use-copy-to-clipboard.js
@@ -1,0 +1,33 @@
+import { useCallback, useState } from 'react'
+
+const copy = toCopy => {
+  const el = document.createElement(`textarea`)
+  el.value = toCopy
+  el.setAttribute(`readonly`, ``)
+  el.style.position = `absolute`
+  el.style.left = `-9999px`
+  document.body.appendChild(el)
+  el.select()
+  document.execCommand(`copy`)
+  document.body.removeChild(el)
+}
+
+const useCopyToClipboard = () => {
+  const [hasCopied, setHasCopied] = useState(false)
+
+  const copyToClipboard = useCallback(
+    toCopy => {
+      if (hasCopied) return
+      copy(toCopy)
+      setHasCopied(true)
+      setTimeout(() => {
+        setHasCopied(false)
+      }, 2000)
+    },
+    [hasCopied]
+  )
+
+  return { hasCopied, copyToClipboard }
+}
+
+export default useCopyToClipboard

--- a/yarn.lock
+++ b/yarn.lock
@@ -9791,7 +9791,7 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.merge@^4.4.0:
+lodash.merge@^4.4.0, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==


### PR DESCRIPTION
Closes #64 

- Added a basic theme editor through `@theme-ui/editor`
- Created a new custom hook `useCopyToClipboard`, and updated the `copy code` component to use this