### PR TITLE
Add peer dependencies to installation instructions

### DIFF
--- a/src/pages/getting-started.mdx
+++ b/src/pages/getting-started.mdx
@@ -17,10 +17,10 @@ other projects you can continue on:
 
 ## Installation
 
-Install the library:
+Install the library and its peer dependencies:
 
 ```js
-yarn add blocks-ui
+yarn add blocks-ui @mdx-js/react @blocks/blocks
 ```
 
 ## Usage


### PR DESCRIPTION
Blocks will not function without these two. There are a few more peer dependencies (`@babel/core` and `@emotion/core`), but things seem to work without them so I'll err on the minimalistic side for now.