### PR TITLE
Small UI improvements to editor panel

### DIFF
--- a/packages/blocks-ui/src/property-controls-panel.js
+++ b/packages/blocks-ui/src/property-controls-panel.js
@@ -10,8 +10,11 @@ const FieldGroup = props => (
     sx={{
       p: 3,
       label: {
+        display: 'block',
         fontSize: 0,
-        fontWeight: 'normal'
+        fontWeight: 'normal',
+        mb: 1,
+        mt: 3
       },
       '.fieldset label': {
         width: '30%'
@@ -25,6 +28,10 @@ const FieldGroup = props => (
         '&:hover': {
           border: 'thin solid #83898f'
         }
+      },
+      'input[type="checkbox"]': {
+        height: 'auto',
+        width: 'auto'
       },
       '.fieldset': {
         display: 'flex',
@@ -42,8 +49,10 @@ const FieldGroup = props => (
       h4: {
         fontSize: 0,
         fontWeight: 500,
+        letterSpacing: 3,
         mt: 0,
-        mb: 2
+        mb: 2,
+        textTransform: 'uppercase'
       },
       borderBottom: 'thin solid #e1e6eb'
     }}

--- a/packages/blocks-ui/src/property-controls-panel.js
+++ b/packages/blocks-ui/src/property-controls-panel.js
@@ -31,6 +31,7 @@ const FieldGroup = props => (
       },
       'input[type="checkbox"]': {
         height: 'auto',
+        mr: 2,
         width: 'auto'
       },
       '.fieldset': {


### PR DESCRIPTION
Mostly around styling of checkboxes + `h4` elements

![image](https://user-images.githubusercontent.com/485747/70497526-8b3f8a00-1b67-11ea-9ba8-9de59478cd2a.png)

Theme values should be used for the colors, but for now this is a quick improvement that makes the UI feel a bit nicer and use less vertical space with checkboxes :)
