### PR TITLE
Add white background to active tab 

### DIFF
--- a/packages/blocks-ui/src/side-panel.js
+++ b/packages/blocks-ui/src/side-panel.js
@@ -114,9 +114,7 @@ export default ({
         <TabPanel>
           {activeTab === 1 ? (
             <BlocksListing components={blocks} theme={theme} />
-          ) : (
-            '#fff'
-          )}
+          ) : null}
         </TabPanel>
         <TabPanel>
           <ThemePanel theme={theme} setTheme={setTheme} />

--- a/packages/blocks-ui/src/side-panel.js
+++ b/packages/blocks-ui/src/side-panel.js
@@ -49,7 +49,7 @@ export default ({
           sx={{
             ...baseTabStyles,
             borderColor: activeTab === 0 ? 'transparent' : 'border',
-            backgroundColor: activeTab === 0 ? null : '#fafafa'
+            backgroundColor: activeTab === 0 ? '#fff' : '#fafafa'
           }}
         >
           Editor
@@ -60,7 +60,7 @@ export default ({
             borderLeft: '1px solid',
             borderRight: '1px solid',
             borderColor: activeTab === 1 ? 'transparent' : 'border',
-            backgroundColor: activeTab === 1 ? null : '#fafafa'
+            backgroundColor: activeTab === 1 ? '#fff' : '#fafafa'
           }}
         >
           Components
@@ -69,7 +69,7 @@ export default ({
           sx={{
             ...baseTabStyles,
             borderColor: activeTab === 2 ? 'transparent' : 'border',
-            backgroundColor: activeTab === 2 ? null : '#fafafa'
+            backgroundColor: activeTab === 2 ? '#fff' : '#fafafa'
           }}
         >
           Theme
@@ -114,7 +114,9 @@ export default ({
         <TabPanel>
           {activeTab === 1 ? (
             <BlocksListing components={blocks} theme={theme} />
-          ) : null}
+          ) : (
+            '#fff'
+          )}
         </TabPanel>
         <TabPanel>
           <ThemePanel theme={theme} setTheme={setTheme} />


### PR DESCRIPTION
Fixes background content being visible on scroll. Small fix for tab showing content in the background.

<img width="685" alt="Screen Shot 2019-12-27 at 7 37 46 PM" src="https://user-images.githubusercontent.com/13269277/71537376-b6a0d380-28e0-11ea-830c-858a35ff3bfa.png">
