### PR TITLE
Independent scrolling for canvas and tree view

### DIFF
--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -18,7 +18,6 @@ const Wrap = props => (
   <div
     sx={{
       position: 'relative',
-      height: '100%',
       backgroundColor: 'white',
       overflow: 'auto'
     }}

--- a/packages/blocks-ui/src/panels/tree.js
+++ b/packages/blocks-ui/src/panels/tree.js
@@ -66,7 +66,6 @@ export default () => {
   return (
     <div
       sx={{
-        height: '100%',
         py: 2,
         overflow: 'auto',
         borderRight: '1px solid',


### PR DESCRIPTION
When you have many blocks in the editor, both the code and tree view become very long. This PR makes them scrollable, independent of each other, and the rest of the site.