### PR TITLE
Update function name to fix broken parent selector

### DIFF
--- a/packages/blocks-ui/src/providers/code.js
+++ b/packages/blocks-ui/src/providers/code.js
@@ -57,7 +57,7 @@ export const CodeProvider = ({ children, initialCode }) => {
     })
   }
 
-  const selectParentofCurrentElement = () => {
+  const selectParentOfCurrentElement = () => {
     if (codeState.currentElementData.parentId) {
       setCurrentElementId(codeState.currentElementData.parentId)
     } else {
@@ -198,7 +198,7 @@ export const CodeProvider = ({ children, initialCode }) => {
         setCurrentElementId,
         removeCurrentElement,
         cloneCurrentElement,
-        selectParentofCurrentElement,
+        selectParentOfCurrentElement,
         updateSxProp,
         onDragEnd,
         onBeforeDragStart


### PR DESCRIPTION
Just a minor typo here that was causing the parent selector in the editor to break.