### PR TITLE
Sync tree to canvas hovered element

### DIFF
--- a/packages/blocks-ui/src/panels/tree.js
+++ b/packages/blocks-ui/src/panels/tree.js
@@ -8,6 +8,7 @@ const Tree = ({
   tree,
   depth,
   selectedId,
+  hoveredId,
   onSelect,
   onMouseEnter,
   onMouseLeave
@@ -29,7 +30,12 @@ const Tree = ({
           pl: depth * 16, // Indent based on depth
           textAlign: 'left',
           color: tree.id === selectedId ? 'background' : 'text',
-          backgroundColor: tree.id === selectedId ? 'primary' : 'transparent',
+          backgroundColor:
+            tree.id === selectedId
+              ? 'primary'
+              : tree.id === hoveredId
+              ? 'border'
+              : 'transparent',
           border: 0,
           cursor: 'pointer',
           outline: 0,
@@ -61,6 +67,7 @@ const Tree = ({
           tree={child}
           depth={depth + 1}
           selectedId={selectedId}
+          hoveredId={hoveredId}
           onSelect={onSelect}
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
@@ -74,6 +81,7 @@ const TreePanel = () => {
   const {
     tree,
     currentElementId,
+    currentHoveredElementId,
     setCurrentElementId,
     setCurrentHoveredElementId
   } = useCode()
@@ -94,6 +102,7 @@ const TreePanel = () => {
           tree={child}
           depth={0}
           selectedId={currentElementId}
+          hoveredId={currentHoveredElementId}
           onSelect={elementId => {
             setCurrentElementId(elementId)
             updateActiveTabByName('editor')

--- a/packages/blocks-ui/src/panels/tree.js
+++ b/packages/blocks-ui/src/panels/tree.js
@@ -83,7 +83,8 @@ const TreePanel = () => {
     currentElementId,
     currentHoveredElementId,
     setCurrentElementId,
-    setCurrentHoveredElementId
+    hoverElementId,
+    removeHoveredElementId
   } = useCode()
   const { updateActiveTabByName } = useEditor()
 
@@ -107,8 +108,8 @@ const TreePanel = () => {
             setCurrentElementId(elementId)
             updateActiveTabByName('editor')
           }}
-          onMouseEnter={elementId => setCurrentHoveredElementId(elementId)}
-          onMouseLeave={elementId => setCurrentHoveredElementId()}
+          onMouseEnter={elementId => hoverElementId(elementId)}
+          onMouseLeave={elementId => removeHoveredElementId(elementId)}
         />
       ))}
     </div>

--- a/packages/blocks-ui/src/panels/tree.js
+++ b/packages/blocks-ui/src/panels/tree.js
@@ -4,7 +4,14 @@ import { jsx } from 'theme-ui'
 import { useCode } from '../providers/code'
 import { useEditor } from '../providers/editor'
 
-const Tree = ({ tree, depth, selectedId, onSelect }) => {
+const Tree = ({
+  tree,
+  depth,
+  selectedId,
+  onSelect,
+  onMouseEnter,
+  onMouseLeave
+}) => {
   return (
     <div
       sx={{
@@ -12,6 +19,8 @@ const Tree = ({ tree, depth, selectedId, onSelect }) => {
       }}
     >
       <button
+        onMouseEnter={() => onMouseEnter(tree.id)}
+        onMouseLeave={() => onMouseLeave(tree.id)}
         onClick={() => onSelect(tree.id)}
         sx={{
           appearance: 'none',
@@ -53,6 +62,8 @@ const Tree = ({ tree, depth, selectedId, onSelect }) => {
           depth={depth + 1}
           selectedId={selectedId}
           onSelect={onSelect}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
         />
       ))}
     </div>
@@ -60,7 +71,12 @@ const Tree = ({ tree, depth, selectedId, onSelect }) => {
 }
 
 const TreePanel = () => {
-  const { tree, currentElementId, setCurrentElementId } = useCode()
+  const {
+    tree,
+    currentElementId,
+    setCurrentElementId,
+    setCurrentHoveredElementId
+  } = useCode()
   const { updateActiveTabByName } = useEditor()
 
   return (
@@ -82,6 +98,8 @@ const TreePanel = () => {
             setCurrentElementId(elementId)
             updateActiveTabByName('editor')
           }}
+          onMouseEnter={elementId => setCurrentHoveredElementId(elementId)}
+          onMouseLeave={elementId => setCurrentHoveredElementId()}
         />
       ))}
     </div>

--- a/packages/blocks-ui/src/pragma.js
+++ b/packages/blocks-ui/src/pragma.js
@@ -8,7 +8,11 @@ import { uuidName } from './constants'
 const IGNORED_TYPES = ['path']
 
 export default (type, props, ...children) => {
-  const { currentElementId, setCurrentElementId } = useCode()
+  const {
+    currentElementId,
+    setCurrentElementId,
+    currentHoveredElementId
+  } = useCode()
   const { updateActiveTabByName } = useEditor()
 
   props = props || {}
@@ -16,6 +20,7 @@ export default (type, props, ...children) => {
   delete props[uuidName]
 
   const isCurrentElement = id && id === currentElementId
+  const isHoveredElement = id && id === currentHoveredElementId
 
   if (IGNORED_TYPES.includes(type)) {
     return jsx(type, props, ...children)
@@ -29,6 +34,8 @@ export default (type, props, ...children) => {
         ...sx,
         boxShadow: isCurrentElement
           ? theme => `inset 0px 0px 0px 2px ${theme.colors.primary}`
+          : isHoveredElement
+          ? 'inset 0px 0px 0px 2px #bbbbbb'
           : sx.boxShadow
       },
       onClick: e => {

--- a/packages/blocks-ui/src/pragma.js
+++ b/packages/blocks-ui/src/pragma.js
@@ -12,7 +12,8 @@ export default (type, props, ...children) => {
     currentElementId,
     setCurrentElementId,
     currentHoveredElementId,
-    setCurrentHoveredElementId
+    hoverElementId,
+    removeHoveredElementId
   } = useCode()
   const { updateActiveTabByName } = useEditor()
 
@@ -46,8 +47,8 @@ export default (type, props, ...children) => {
           updateActiveTabByName('editor')
         }
       },
-      onMouseEnter: () => setCurrentHoveredElementId(id),
-      onMouseLeave: () => setCurrentHoveredElementId()
+      onMouseEnter: () => hoverElementId(id),
+      onMouseLeave: () => removeHoveredElementId(id)
     },
     ...children
   )

--- a/packages/blocks-ui/src/pragma.js
+++ b/packages/blocks-ui/src/pragma.js
@@ -11,7 +11,8 @@ export default (type, props, ...children) => {
   const {
     currentElementId,
     setCurrentElementId,
-    currentHoveredElementId
+    currentHoveredElementId,
+    setCurrentHoveredElementId
   } = useCode()
   const { updateActiveTabByName } = useEditor()
 
@@ -44,7 +45,9 @@ export default (type, props, ...children) => {
           setCurrentElementId(id)
           updateActiveTabByName('editor')
         }
-      }
+      },
+      onMouseEnter: () => setCurrentHoveredElementId(id),
+      onMouseLeave: () => setCurrentHoveredElementId()
     },
     ...children
   )

--- a/packages/blocks-ui/src/providers/code.js
+++ b/packages/blocks-ui/src/providers/code.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect, useRef } from 'react'
+import React, { useState, useContext, useEffect } from 'react'
 
 import * as queries from '../queries'
 import * as transforms from '../transforms'
@@ -13,25 +13,11 @@ export const useCode = () => {
   return value
 }
 
-const useRefState = initialValue => {
-  const [state, setState] = useState(initialValue)
-  const stateRef = useRef(state)
-
-  return [
-    state,
-    newState => {
-      setState(newState)
-      stateRef.current = newState
-    },
-    stateRef
-  ]
-}
-
 export const CodeProvider = ({ children, initialCode, onChange }) => {
   const providedBlocks = useBlocks()
 
   const codeWithUuids = transforms.addTuid(initialCode)
-  const [codeState, setCodeState, codeStateRef] = useRefState({
+  const [codeState, setCodeState] = useState({
     currentElementId: null,
     currentElementData: null,
     currentHoveredElementId: null,
@@ -82,14 +68,14 @@ export const CodeProvider = ({ children, initialCode, onChange }) => {
       return
     }
 
-    setCodeState({
-      ...codeStateRef.current,
+    setCodeState(oldCodeState => ({
+      ...oldCodeState,
       currentHoveredElementId: !elementId ? null : elementId,
       currentHoveredElements: [
-        ...codeStateRef.current.currentHoveredElements,
+        ...oldCodeState.currentHoveredElements,
         elementId
       ]
-    })
+    }))
   }
 
   const removeHoveredElementId = elementId => {
@@ -97,17 +83,19 @@ export const CodeProvider = ({ children, initialCode, onChange }) => {
       return
     }
 
-    const newHoveredElements = codeStateRef.current.currentHoveredElements.filter(
-      id => id !== elementId
-    )
+    setCodeState(oldCodeState => {
+      const newHoveredElements = oldCodeState.currentHoveredElements.filter(
+        id => id !== elementId
+      )
 
-    setCodeState({
-      ...codeStateRef.current,
-      currentHoveredElementId:
-        newHoveredElements.length > 0
-          ? newHoveredElements[newHoveredElements.length - 1]
-          : null,
-      currentHoveredElements: newHoveredElements
+      return {
+        ...oldCodeState,
+        currentHoveredElementId:
+          newHoveredElements.length > 0
+            ? newHoveredElements[newHoveredElements.length - 1]
+            : null,
+        currentHoveredElements: newHoveredElements
+      }
     })
   }
 

--- a/packages/blocks-ui/src/providers/code.js
+++ b/packages/blocks-ui/src/providers/code.js
@@ -18,6 +18,7 @@ export const CodeProvider = ({ children, initialCode, onChange }) => {
 
   const codeWithUuids = transforms.addTuid(initialCode)
   const [codeState, setCodeState] = useState({
+    currentHoveredElementId: null,
     currentElementId: null,
     currentElementData: null,
     rawCode: initialCode,
@@ -58,6 +59,13 @@ export const CodeProvider = ({ children, initialCode, onChange }) => {
       ...codeState,
       currentElementId: elementId,
       currentElementData
+    })
+  }
+
+  const setCurrentHoveredElementId = elementId => {
+    setCodeState({
+      ...codeState,
+      currentHoveredElementId: !elementId ? null : elementId
     })
   }
 
@@ -201,6 +209,7 @@ export const CodeProvider = ({ children, initialCode, onChange }) => {
         updateProp,
         setCurrentElementId,
         removeCurrentElement,
+        setCurrentHoveredElementId,
         cloneCurrentElement,
         selectParentOfCurrentElement,
         updateSxProp,


### PR DESCRIPTION
I'm not sure if this is a feature we want, but I was playing around with the idea.

When you hover on a component in the tree panel, the corresponding block is highlighted in the editor. Similarly, when you hover on a block in the editor, the corresponding tree is highlighted.

~There is still a bug when you mouse leaves a subcomponent in the editor but keep your mouse in the parent component, it is not properly selected as the hovered component.~

![hover-sync](https://user-images.githubusercontent.com/3044853/73069129-d5c15f80-3ea4-11ea-854b-9be8f800df64.gif)
