### PR TITLE
Update editor layout grid

### DIFF
--- a/packages/blocks-ui/src/editor.js
+++ b/packages/blocks-ui/src/editor.js
@@ -5,6 +5,7 @@ import { DragDropContext } from '@blocks/react-beautiful-dnd'
 import appTheme from './theme'
 import Canvas from './canvas'
 import Layout from './layout'
+import { headerHeight } from './header'
 import SidePanel from './panels/side'
 import TreePanel from './panels/tree'
 import Providers from './providers'
@@ -13,7 +14,7 @@ import { useCode } from './providers/code'
 const EditorGrid = props => (
   <div
     sx={{
-      height: '100%',
+      height: `calc(100vh - ${headerHeight}px)`,
       width: '100%',
       display: 'grid',
       gridTemplateColumns: '260px 1fr 400px'

--- a/packages/blocks-ui/src/editor.js
+++ b/packages/blocks-ui/src/editor.js
@@ -13,10 +13,10 @@ import { useCode } from './providers/code'
 const EditorGrid = props => (
   <div
     sx={{
+      height: '100%',
       width: '100%',
       display: 'grid',
-      gridTemplateColumns: '260px 1fr 400px',
-      height: 'calc(100vh - 43px)'
+      gridTemplateColumns: '260px 1fr 400px'
     }}
     {...props}
   />

--- a/packages/blocks-ui/src/header.js
+++ b/packages/blocks-ui/src/header.js
@@ -9,6 +9,8 @@ import { IconButton } from './ui'
 
 const { version } = pkg
 
+export const headerHeight = 50
+
 const modes = [
   {
     key: 'canvas',
@@ -93,6 +95,7 @@ const ToolbarButton = ({ label, onClick, isActive, Icon }) => (
 const Header = () => (
   <header
     sx={{
+      height: headerHeight,
       display: 'flex',
       justifyContent: 'space-between',
       width: '100%',

--- a/packages/blocks-ui/src/layout.js
+++ b/packages/blocks-ui/src/layout.js
@@ -7,24 +7,26 @@ import Header from './header'
 export default ({ children }) => {
   return (
     <Styled.root>
-      <Header />
       <Global
         styles={{
           '*': {
             boxSizing: 'border-box'
           },
-          body: {
-            margin: 0
+          'html, body': {
+            margin: 0,
+            padding: 0
           }
         }}
       />
       <div
-        sx={{
-          display: 'flex',
-          height: 'calc(100vh - 43px)'
+        css={{
+          display: 'grid',
+          gridTemplateRows: 'auto 1fr',
+          minHeight: '100vh'
         }}
       >
-        {children}
+        <Header />
+        <main>{children}</main>
       </div>
     </Styled.root>
   )

--- a/packages/blocks-ui/src/layout.js
+++ b/packages/blocks-ui/src/layout.js
@@ -2,7 +2,7 @@
 import { Styled, jsx } from 'theme-ui'
 import { Global } from '@emotion/core'
 
-import Header from './header'
+import Header, { headerHeight } from './header'
 
 export default ({ children }) => {
   return (
@@ -21,7 +21,7 @@ export default ({ children }) => {
       <div
         css={{
           display: 'grid',
-          gridTemplateRows: 'auto 1fr',
+          gridTemplateRows: `${headerHeight}px 1fr`,
           minHeight: '100vh'
         }}
       >


### PR DESCRIPTION
Currently when you land on the demo you can scroll down which you shouldn't be able to. This PR fixes the whitespace that is causing this