### PR TITLE
Use monaco for code editor

### DIFF
--- a/.changeset/two-buttons-listen.md
+++ b/.changeset/two-buttons-listen.md
@@ -1,5 +1,5 @@
 ---
-'blocks-ui': minor
+'blocks-ui': patch
 ---
 
 Use Monaco for the canvas code editor.

--- a/.changeset/two-buttons-listen.md
+++ b/.changeset/two-buttons-listen.md
@@ -2,4 +2,4 @@
 'blocks-ui': minor
 ---
 
-use monaco editor for canvas code editor
+Use Monaco for the canvas code editor.

--- a/.changeset/two-buttons-listen.md
+++ b/.changeset/two-buttons-listen.md
@@ -1,0 +1,5 @@
+---
+'blocks-ui': minor
+---
+
+use monaco editor for canvas code editor

--- a/packages/blocks-ui/package.json
+++ b/packages/blocks-ui/package.json
@@ -18,6 +18,7 @@
     "@emotion/cache": "^10.0.19",
     "@emotion/core": "^10.0.22",
     "@mdx-js/react": "^1.5.1",
+    "@monaco-editor/react": "^3.0.1",
     "@reach/tabs": "^0.7.0",
     "@theme-ui/components": "^0.2.50",
     "@theme-ui/editor": "^0.2.51",

--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -4,8 +4,6 @@ import { jsx } from 'theme-ui'
 import prettier from 'prettier/standalone'
 import parserJS from 'prettier/parser-babylon'
 
-import { Clipboard, Check } from 'react-feather'
-
 import CodeEditor from './code-editor'
 
 import * as transforms from './transforms'
@@ -13,8 +11,6 @@ import { useEditor } from './providers/editor'
 import { useCode } from './providers/code'
 import InlineRender from './inline-render'
 import { PreviewArea, Device } from './device-preview'
-import { IconButton } from './ui'
-import useCopyToClipboard from './use-copy-to-clipboard'
 import { useScope } from './providers/scope'
 import { useCanvas } from './providers/canvas'
 import { useElementSize } from './use-element-size'
@@ -41,47 +37,36 @@ const CanvasWrap = props => {
   )
 }
 
-const Copy = ({ toCopy }) => {
-  const { hasCopied, copyToClipboard } = useCopyToClipboard()
-
-  return (
-    <IconButton
-      onClick={() => copyToClipboard(toCopy)}
-      sx={{ position: 'absolute', right: '-4px' }}
-    >
-      {hasCopied ? (
-        <Check sx={{ color: 'green' }} aria-label="Copied" />
-      ) : (
-        <Clipboard size={16} aria-label="Copy" />
-      )}
-    </IconButton>
-  )
-}
-
 const Canvas = () => {
-  const [error, setError] = useState(null)
   const { theme, ...scope } = useScope()
   const { code, transformedCode, editCode } = useCode()
   const { mode } = useEditor()
-  const rawCode = transforms.toRawJSX(code)
-  const formattedCode = prettier.format(rawCode, {
-    parser: 'babel',
-    plugins: [parserJS]
-  })
+
+  const [formattedCode, setFormattedCode] = useState('')
+
+  useEffect(() => {
+    if (mode === 'code') {
+      const rawCode = transforms.toRawJSX(code)
+      setFormattedCode(
+        prettier.format(rawCode, {
+          parser: 'babel',
+          plugins: [parserJS]
+        })
+      )
+    }
+  }, [mode])
 
   const onCodeChange = code => {
     try {
       editCode(code)
-      setError(null)
     } catch (e) {
-      setError(e.toString())
+      // do nothing as they are displayed in the editor
     }
   }
 
   if (mode === 'code') {
     return (
       <CanvasWrap>
-        <Copy toCopy={formattedCode} />
         <CodeEditor code={formattedCode} onChange={onCodeChange} />
       </CanvasWrap>
     )

--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -60,7 +60,7 @@ const Canvas = () => {
     try {
       editCode(code)
     } catch (e) {
-      // do nothing as they are displayed in the editor
+      // do nothing as the errors are displayed in the editor
     }
   }
 

--- a/packages/blocks-ui/src/canvas.js
+++ b/packages/blocks-ui/src/canvas.js
@@ -1,11 +1,12 @@
 /** @jsx jsx */
 import { useState, useRef, useEffect } from 'react'
 import { jsx } from 'theme-ui'
-import { Textarea } from '@theme-ui/components'
 import prettier from 'prettier/standalone'
 import parserJS from 'prettier/parser-babylon'
 
 import { Clipboard, Check } from 'react-feather'
+
+import CodeEditor from './code-editor'
 
 import * as transforms from './transforms'
 import { useEditor } from './providers/editor'
@@ -68,39 +69,20 @@ const Canvas = () => {
     plugins: [parserJS]
   })
 
+  const onCodeChange = code => {
+    try {
+      editCode(code)
+      setError(null)
+    } catch (e) {
+      setError(e.toString())
+    }
+  }
+
   if (mode === 'code') {
     return (
       <CanvasWrap>
-        <pre
-          sx={{
-            mt: 0,
-            mb: 0,
-            backgroundColor: 'rgba(206, 17, 38, 0.05)',
-            fontSize: '8pt'
-          }}
-        >
-          {error}
-        </pre>
         <Copy toCopy={formattedCode} />
-        <Textarea
-          sx={{
-            height: '100%',
-            border: 'none',
-            borderRadius: 0,
-            fontFamily: 'Menlo, monospace',
-            fontSize: '14px'
-          }}
-          onChange={e => {
-            try {
-              editCode(e.target.value)
-              setError(null)
-            } catch (err) {
-              setError(err.toString())
-            }
-          }}
-        >
-          {formattedCode}
-        </Textarea>
+        <CodeEditor code={formattedCode} onChange={onCodeChange} />
       </CanvasWrap>
     )
   }

--- a/packages/blocks-ui/src/code-editor.js
+++ b/packages/blocks-ui/src/code-editor.js
@@ -1,0 +1,50 @@
+/** @jsx jsx */
+import { useRef } from 'react'
+import { jsx } from 'theme-ui'
+import { Textarea } from '@theme-ui/components'
+import Monaco from '@monaco-editor/react'
+
+const CodeEditor = ({ code, onChange }) => {
+  const editorRef = useRef(null)
+
+  const handleEditorDidMount = (_, editor) => {
+    editorRef.current = editor
+
+    editorRef.current.onDidChangeModelContent(ev => {
+      onChange(editorRef.current.getValue())
+    })
+  }
+
+  return (
+    <Monaco
+      height="100%"
+      value={code}
+      language="javascript"
+      editorDidMount={handleEditorDidMount}
+      options={{
+        minimap: {
+          enabled: false
+        }
+      }}
+    />
+  )
+}
+
+export default CodeEditor
+
+/*
+    <Textarea
+      sx={{
+        height: '100%',
+        border: 'none',
+        borderRadius: 0,
+        fontFamily: 'Menlo, monospace',
+        fontSize: '14px'
+      }}
+      onChange={e => {
+        onChange(e.target.value)
+      }}
+    >
+      {code}
+    </Textarea>
+*/

--- a/packages/blocks-ui/src/code-editor.js
+++ b/packages/blocks-ui/src/code-editor.js
@@ -1,8 +1,35 @@
 /** @jsx jsx */
 import { useRef } from 'react'
 import { jsx } from 'theme-ui'
-import { Textarea } from '@theme-ui/components'
+
+import { Clipboard, Check } from 'react-feather'
+
 import Monaco from '@monaco-editor/react'
+
+import useCopyToClipboard from './use-copy-to-clipboard'
+import { IconButton } from './ui'
+
+const Copy = ({ toCopy }) => {
+  const { hasCopied, copyToClipboard } = useCopyToClipboard()
+
+  return (
+    <IconButton
+      onClick={() => copyToClipboard(toCopy)}
+      sx={{
+        position: 'absolute',
+        right: '10px',
+        zIndex: 1,
+        cursor: 'pointer'
+      }}
+    >
+      {hasCopied ? (
+        <Check sx={{ color: 'green' }} aria-label="Copied" />
+      ) : (
+        <Clipboard size={16} aria-label="Copy" />
+      )}
+    </IconButton>
+  )
+}
 
 const CodeEditor = ({ code, onChange }) => {
   const editorRef = useRef(null)
@@ -16,35 +43,26 @@ const CodeEditor = ({ code, onChange }) => {
   }
 
   return (
-    <Monaco
-      height="100%"
-      value={code}
-      language="javascript"
-      editorDidMount={handleEditorDidMount}
-      options={{
-        minimap: {
-          enabled: false
-        }
-      }}
-    />
+    <div sx={{ height: '100%' }}>
+      <Copy toCopy={code} />
+
+      <Monaco
+        height="100%"
+        value={code}
+        language="javascript"
+        editorDidMount={handleEditorDidMount}
+        theme="light"
+        options={{
+          minimap: {
+            enabled: false
+          },
+          scrollbar: {
+            vertical: 'hidden'
+          }
+        }}
+      />
+    </div>
   )
 }
 
 export default CodeEditor
-
-/*
-    <Textarea
-      sx={{
-        height: '100%',
-        border: 'none',
-        borderRadius: 0,
-        fontFamily: 'Menlo, monospace',
-        fontSize: '14px'
-      }}
-      onChange={e => {
-        onChange(e.target.value)
-      }}
-    >
-      {code}
-    </Textarea>
-*/

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,6 +1476,11 @@
   resolved "https://registry.yarnpkg.com/@mikaelkristiansson/domready/-/domready-1.0.10.tgz#f6d69866c0857664e70690d7a0bfedb72143adb5"
   integrity sha512-6cDuZeKSCSJ1KvfEQ25Y8OXUjqDJZ+HgUs6dhASWbAX8fxVraTfPsSeRe2bN+4QJDsgUaXaMWBYfRomCr04GGg==
 
+"@monaco-editor/react@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-3.0.1.tgz#98fcfb1a5ccf7cc1f376132ffcec66df2a4588cc"
+  integrity sha512-RRe4OkO7jTgPTtgJMFWUNxI+hFci/6Et6mpN9Tu2i+Ev8A1uPNoQVHix9mQPn9TWUkv+cgGacuKZyVt6wG6SZA==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
Closes: #241 

Use [monaco-react](https://github.com/suren-atoyan/monaco-react) for the code editor. I added minimal options, but there [are a bunch available](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditoroptions.html) if we want to customize it further. I had some difficulty getting it to work with themes other than light and dark, but honestly didn't look too hard. We may want to use a custom theme and that [option is available](https://github.com/suren-atoyan/monaco-react/issues/50). I removed the previous error reporting in favour of the inline ones. Maybe we want to prevent switching editor modes if there is an error?
