### PR TITLE
Update link to docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ A JSX-based page builder for creating beautiful websites without writing code.
 ![Blocks demo](https://user-images.githubusercontent.com/1424573/69644337-c13a2580-1021-11ea-8c76-379386372db1.gif)
 
 
-[Read the docs &rarr;](https://blocks-ui.com)
+[Read the docs &rarr;](https://blocks-ui.com/docs)
 
 ---
 


### PR DESCRIPTION
`Read the docs` link was taking us to the home page of blocks-ui.com. Changing it to take to the actual docs page.