### PR TITLE
fix: disable dropping for components tab

### DIFF
--- a/.changeset/spicy-parents-exercise.md
+++ b/.changeset/spicy-parents-exercise.md
@@ -1,0 +1,5 @@
+---
+"blocks-ui": patch
+---
+
+Disable dropping for components tab

--- a/packages/blocks-ui/src/panels/blocks-listing.js
+++ b/packages/blocks-ui/src/panels/blocks-listing.js
@@ -85,7 +85,7 @@ export default () => {
   return (
     <Box p={3}>
       <ThemeProvider theme={theme}>
-        <Droppable droppableId="components">
+        <Droppable isDropDisabled droppableId="components">
           {(provided, _snapshot) => (
             <div {...provided.droppableProps} ref={provided.innerRef}>
               {list}


### PR DESCRIPTION
**Current Behavior:**

We can drag components from the preview to the side panel and the component list can be re-arranged but as soon as we drop the component; list is reset.

**Updated Behavior:**

Disable dropping on the side panel. Preview:
![Avoid_Dropping](https://user-images.githubusercontent.com/22376783/74103209-586a4000-4b70-11ea-964e-f05070b6d0e4.gif)
