### PR TITLE
Add check for sx value being undefined

### DIFF
--- a/.changeset/beige-pandas-return.md
+++ b/.changeset/beige-pandas-return.md
@@ -1,0 +1,5 @@
+---
+"blocks-ui": patch
+---
+
+Remove null literal from showing up in the editor

--- a/packages/blocks-ui/src/babel-plugins/apply-sx-prop.js
+++ b/packages/blocks-ui/src/babel-plugins/apply-sx-prop.js
@@ -20,6 +20,10 @@ export default (api, { elementId, sx }) => {
             node => node && node.name && node.name.name === 'sx'
           )
 
+          if (typeof value === 'undefined') {
+            return
+          }
+
           if (!sxProp) {
             path.node.attributes.push(
               t.jSXAttribute(

--- a/packages/blocks-ui/src/babel-plugins/apply-sx-prop.test.js
+++ b/packages/blocks-ui/src/babel-plugins/apply-sx-prop.test.js
@@ -30,3 +30,21 @@ test('applies a falsey prop to the sx object', () => {
 }}>Hello, world!</h1>`
   )
 })
+
+test('should remove sx value when undefined', () => {
+  const result = testPlugin(plugin, '<h1 ___uuid="abc">Hello, world!</h1>', {
+    elementId: 'abc',
+    sx: {
+      pt: 3,
+      pr: undefined,
+      fontSize: 0
+    }
+  })
+
+  expect(result).toEqual(
+    `<h1 ___uuid="abc" sx={{
+  pt: 3,
+  fontSize: 0
+}}>Hello, world!</h1>`
+  )
+})


### PR DESCRIPTION
Removes null literal from showing up in the editor. Closes #65
