### PR TITLE
Fix horizontally overflowing images

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -27,6 +27,9 @@ export default ({
         },
         body: {
           margin: 0
+        },
+        img: {
+          maxWidth: '100%'
         }
       }}
     />

--- a/src/components/minimal-layout.js
+++ b/src/components/minimal-layout.js
@@ -2,12 +2,20 @@
 import { jsx, Styled } from 'theme-ui'
 import { Container } from '@theme-ui/components'
 import { Link } from 'gatsby'
+import { Global } from '@emotion/core'
 
 import SEO from './seo'
 
 export default ({ children, _frontmatter: { title } = {} }) => (
   <Styled.root>
     <SEO title={title} />
+    <Global
+      styles={{
+        img: {
+          maxWidth: '100%'
+        }
+      }}
+    />
     <Container as="main" mb={[3, 4, 5]}>
       <Link to="/">
         <img


### PR DESCRIPTION
Images are no longer overflowing on the home page and documentation pages.

Before:
![before](https://user-images.githubusercontent.com/21107799/76139966-a5f8a080-607b-11ea-87f2-32938d2990bd.png)
After:
![after](https://user-images.githubusercontent.com/21107799/76159588-4916ec00-6148-11ea-9692-e8c60af603b3.png)

Fixes #313 